### PR TITLE
chore: pin mise tool versions for reproducible builds

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,15 +1,15 @@
 [tools]
 # Go toolchain
-go = "latest"
+go = "1.25.0"
 
 # Development tools (CI uses dedicated actions)
-pinact = "latest"
+pinact = "3.4.2"
 
 # GitHub Actions linting tools
-actionlint = "latest"
+actionlint = "1.7.7"
 golangci-lint = "v2.4.0"
-"npm:@goreleaser/goreleaser" = "latest"
-terraform = "latest"
+"npm:@goreleaser/goreleaser" = "2.11.2"
+terraform = "1.13.0"
 
 [env]
 # Go environment variables


### PR DESCRIPTION
## Summary
Pin all `latest` tool versions in `.mise.toml` to specific versions for reproducible development environments.

## Changes
- **Go**: `latest` → `1.25.0` (current stable release)
- **pinact**: `latest` → `3.4.2` (action hash pinning security tool)
- **actionlint**: `latest` → `1.7.7` (GitHub Actions workflow linting)
- **npm:@goreleaser/goreleaser**: `latest` → `2.11.2` (release automation)
- **terraform**: `latest` → `1.13.0` (infrastructure as code)

## Benefits
✅ **Reproducible builds**: All developers and CI use identical tool versions  
✅ **Prevent breaking changes**: Avoid unexpected tool updates breaking builds  
✅ **Security**: Fixed versions prevent supply chain attacks via version pinning  
✅ **Debugging**: Easier to troubleshoot issues with known tool versions  
✅ **Compliance**: Meets best practices for production-ready projects  

## Verification
- [x] All tools install successfully with pinned versions
- [x] `mise list --current` shows correct pinned versions
- [x] No functionality changes, purely version management

## Type
- [x] Maintenance/Infrastructure
- [ ] Feature
- [ ] Bug Fix

This follows security and reproducibility best practices for development toolchain management.